### PR TITLE
compile and install enhancements

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,8 +17,7 @@
 #
 
 SET(COMMON_DEPS
-    libsystemd-daemon
-    libsystemd-journal
+    libsystemd
     )
 
 IF (CMAKE_BUILD_TYPE MATCHES "DEBUG")


### PR DESCRIPTION
The compilation changes are needed when compiling for an OpenEmbedded distro.

The cynara-db-migration change was not absolutely needed, but looked like the right thing to do.
