### PR TITLE
Don't hardcode libdir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ ENDIF (SYSTEMD_DEP_FOUND)
 ########################  directory configuration  ############################
 
 SET(LIB_DIR
-    "${CMAKE_INSTALL_PREFIX}/lib"
+    "${CMAKE_INSTALL_LIBDIR}"
     CACHE PATH
     "Object code libraries directory")
 


### PR DESCRIPTION
cmake already has defined variables for libdir.  It's best to use this instead of hardcoding our own which may break distro compatibility (specifically distros that support multilib).