### PR TITLE
Improves the use of GNUInstallDirs for yocto

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,31 +43,27 @@ ENDIF (NOT BUILD_COMMONS AND NOT BUILD_SERVICE AND NOT BUILD_DBUS)
 
 ########################## search for packages ################################
 
-#1st case. User choose to build with systemd.
-IF (DEFINED BUILD_WITH_SYSTEMD AND BUILD_WITH_SYSTEMD)
-    PKG_CHECK_MODULES(SYSTEMD_DEP
-        REQUIRED
-        libsystemd-daemon
-        libsystemd-journal
-        )
-ENDIF (DEFINED BUILD_WITH_SYSTEMD AND BUILD_WITH_SYSTEMD)
+#Search the new libsystemd package
+PKG_CHECK_MODULES(SYSTEMD_DEP QUIET libsystemd)
 
-#2nd case. User choose not to build with systemd. Noting to do in this case.
-#IF (DEFINED BUILD_WITH_SYSTEMD AND NOT BUILD_WITH_SYSTEMD)
-#ENDIF (DEFINED BUILD_WITH_SYSTEMD AND NOT BUILD_WITH_SYSTEMD)
-
-#3rd case. User did not choose. If we can we will use systemd.
-IF (NOT DEFINED BUILD_WITH_SYSTEMD)
+#Fallback to the older libsystemd packages
+IF(NOT SYSTEMD_DEP_FOUND)
     PKG_CHECK_MODULES(SYSTEMD_DEP
         QUIET
         libsystemd-daemon
         libsystemd-journal
         )
+ENDIF(NOT SYSTEMD_DEP_FOUND)
 
-    IF (SYSTEMD_DEP_FOUND)
+#Enforce and check
+IF(SYSTEMD_DEP_FOUND)
+    #Enforce use of systemd if present
+    IF(NOT DEFINED BUILD_WITH_SYSTEMD)
         SET(BUILD_WITH_SYSTEMD ON)
-    ENDIF (SYSTEMD_DEP_FOUND)
-ENDIF (NOT DEFINED BUILD_WITH_SYSTEMD)
+    ENDIF()
+ELSEIF(BUILD_WITH_SYSTEMD)
+    MESSAGE(FATAL_ERROR "Can't find libsystemd")
+ENDIF()
 
 ########################  directory configuration  ############################
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,37 +72,37 @@ ENDIF (NOT DEFINED BUILD_WITH_SYSTEMD)
 ########################  directory configuration  ############################
 
 SET(LIB_DIR
-    "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}"
+    "${CMAKE_INSTALL_FULL_LIBDIR}"
     CACHE PATH
     "Object code libraries directory")
 
 SET(BIN_DIR
-    "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}"
+    "${CMAKE_INSTALL_FULL_BINDIR}"
     CACHE PATH
     "User executables directory")
 
 SET(SBIN_DIR
-    "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_SBINDIR}"
+    "${CMAKE_INSTALL_FULL_SBINDIR}"
     CACHE PATH
     "System admin executables directory")
 
 SET(SYS_CONFIG_DIR
-    "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_SYSCONFDIR}"
+    "${CMAKE_INSTALL_FULL_SYSCONFDIR}"
     CACHE PATH
     "Read-only single-machine data directory")
 
 SET(INCLUDE_DIR
-    "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}"
+    "${CMAKE_INSTALL_FULL_INCLUDEDIR}"
     CACHE PATH
     "Header files directory")
 
 SET(LOCAL_STATE_DIR
-    "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LOCALSTATEDIR}"
+    "${CMAKE_INSTALL_FULL_LOCALSTATEDIR}"
     CACHE PATH
     "Modifiable single-machine data directory")
 
 SET(DATA_ROOT_DIR
-    "${CMAKE_INSTALL_PREFIX}/share"
+    "${CMAKE_INSTALL_FULL_DATAROOTDIR}"
     CACHE PATH
     "Read-only architecture-independent data root directory")
 


### PR DESCRIPTION
The previous implementation was not fully compliant with
standards. It was missing some of the predefined variable
DATAROOTDIR, it was missing specificity of
CMAKE_INSTALL_FULL_SYSCONFDIR.

It also was not compatible with yocto build.

Signed-off-by: José Bollo <jose.bollo@iot.bzh>